### PR TITLE
feat(registry): Add CLI validation during registry update

### DIFF
--- a/.github/workflows/update_registry_from_pr.yaml
+++ b/.github/workflows/update_registry_from_pr.yaml
@@ -34,9 +34,13 @@ jobs:
     - name: Run registry updater
       run: |
         set -e
+        python -m pip install pipx
+        python -m pipx ensurepath
+        
         python update_registry.py \
           --before "${{ steps.get_base_sha.outputs.base_sha }}" \
-          --after "HEAD"
+          --after "HEAD" \
+          --check-cli
 
     - name: Create PR comment
       uses: actions/github-script@v6


### PR DESCRIPTION
- Implement `validate_cli_installation()` to test CLI installations
- Add `--check-cli` flag to update_registry.py for optional validation
- Update GitHub Actions workflow to run CLI validation during registry update
- Use temporary pipx environment for safe and isolated CLI testing