### PR TITLE
update-cli(shard): Remove h5 support and unnecessary dependency

### DIFF
--- a/cli-shard/pyproject.toml
+++ b/cli-shard/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cli-shard"
-version = "0.1.0"
+version = "0.1.1"
 description = "Shard the input file into smaller files"
 authors = [
     { name = "Honi Zhang", email = "zhang.h.n@foxmail.com" }
@@ -12,8 +12,7 @@ dependencies = [
     "click",
     "pandas",
     "numpy",
-    "openpyxl",
-    "table"
+    "openpyxl"
 ]
 
 [project.scripts]

--- a/cli-shard/src/cli_shard/cli.py
+++ b/cli-shard/src/cli_shard/cli.py
@@ -8,7 +8,7 @@ import click
     '--input_file', '-i',
     type=click.Path(exists=True, resolve_path=True, path_type=Path),
     required=True,
-    help="Input file path (supported formats: csv/tsv/xlsx/xls/txt/h5/pkl)"
+    help="Input file path (supported formats: csv/tsv/xlsx/xls/txt/pkl)"
 )
 @click.option(
     '--output_dir', '-o',
@@ -43,7 +43,6 @@ def shard(input_file: Path, output_dir: Path, num_shard: int, shuffle: bool = Fa
         '.txt': pd.read_table,
         '.tsv': pd.read_table,
         '.csv': pd.read_csv,
-        '.h5': pd.read_hdf,
         '.pkl': pd.read_pickle,
         '.xlsx': pd.read_excel,
         '.xls': pd.read_excel


### PR DESCRIPTION
- Remove 'table' dependency from pyproject.toml
- Remove .h5 file format support from input file parsing
- Update version to 0.1.1
- Simplify input file format help text